### PR TITLE
FE: fixed issue with handling scalar fields named "New field" converted to reference on the root level

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -131,7 +131,7 @@ const getEntityData = (container, entityId) => {
 }
 
 const convertJsonToAvro = (jsonSchema, schemaName) => {
-	jsonSchema = { ...jsonSchema, type: 'record' };
+	jsonSchema = { ...jsonSchema, name: schemaName, type: 'record' };
 	const customProperties = getCustomProperties(getEntityLevelConfig(), jsonSchema);
 	const avroSchema = {
 		...convertSchema(jsonSchema),

--- a/forward_engineering/helpers/generalHelper.js
+++ b/forward_engineering/helpers/generalHelper.js
@@ -99,7 +99,7 @@ const compareSchemasByStructure = (schema1, schema2) => {
 	const propertiesToCompare = ['type', 'name', 'fields', 'items', 'values', 'logicalType', 'precision', 'scale', 'size'];
 
 	return _.isEqualWith(schema1, schema2, (schema1, schema2, key) => {
-		if (!propertiesToCompare.includes(key)) {
+		if (!_.isUndefined(key) && !propertiesToCompare.includes(key)) {
 			return true;
 		}
 	});


### PR DESCRIPTION
The root cause is not so obvious.
Avro has named types that may be references and regular scalar types. If we create a reference to scalar type (string) - we just resolve it on FE.
 
Also, in Avro schema, only one definition of schema type should exist.  If we have two fields with the same name we check their structure and if it's equal - we convert second one to the reference on the first definition.

The first issue - we didn't set name for root record (collection). As collection has "record" type in Avro terms - it is a named type, so it's definition by itself. To compare two definitions schema we set default name (if no name is set). Default name is - "New field". So if there is already definition with "New field" name algorithm will try to compare them to find only one definition to make schema valid.

But there is the second issue - comparator works incorrectly when schema is empty. String properties have string schema with value: "string". So there are no properties here to compare.

I've fixed both issues