### PR TITLE
FE: fix nullable handling on entity-level

### DIFF
--- a/forward_engineering/helpers/convertJsonSchemaToAvro.js
+++ b/forward_engineering/helpers/convertJsonSchemaToAvro.js
@@ -37,22 +37,17 @@ const prepareSchema = schema => {
 		type: !schema.type || (schema.$ref && !schema.choice) ? getTypeFromReference(schema) : getAvroType(schema.type),
 	};
 
-	if (!schema.$ref) {
-		return typeSchema;
+	if (!typeSchema.nullable) {
+		return _.omit(typeSchema, 'nullable');
 	}
 
-	const udt = getUdtItem(typeSchema.type);
-	if (udt?.isCollectionReference && typeSchema.nullable) {
-		return {
-			..._.omit(typeSchema, ['nullable', '$ref']),
-			type: [
-				'null',
-				typeSchema.type
-			],
-		};
-	}
-
-	return typeSchema;
+	return {
+		..._.omit(typeSchema, ['nullable', '$ref']),
+		type: [
+			'null',
+			typeSchema.type
+		],
+	};
 };
 
 const getAvroType = type => {


### PR DESCRIPTION
Changed this logic to a more general approach, because when we are on the entity level, the application resolves collection references. So they have no $ref anymore. 
Nullable is a property that can be only on the collection references and it should be filtered after this function