### PR TITLE
FE: fixed namespaces for references in confluent schema for model level

### DIFF
--- a/forward_engineering/helpers/udtHelper.js
+++ b/forward_engineering/helpers/udtHelper.js
@@ -216,12 +216,10 @@ const convertCollectionReferences = (entities, options) => {
 				version: getConfluentSchemaVersion(definition.confluentVersion),
 			}];
 
-			const addNamespace = !entitiesIds.includes(field.ref);
-
 			return {
 				...field,
 				$ref: `#/definitions/${definitionName}`,
-				namespace: addNamespace && (field.namespace || field.parentBucketName),
+				namespace: field.namespace || field.parentBucketName,
 				default: field.nullable ? null : field.default,
 			};
 		});


### PR DESCRIPTION
This check is not needed anymore as we adding namespaces for references both on entity and model level