### PR TITLE
Fix/HCK-4329 avro union schema with references convert to polyglot

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1720,6 +1720,7 @@ making sure that you maintain a proper JSON format.
 		],
 		"reference": [
 			"name",
+			"displayName",
 			"schemaId",
 			{
 				"propertyName": "Doc",


### PR DESCRIPTION
Added missing `displayName` property for reference type for correct retrieval it value from Polyglot