### PR TITLE
FE: fixed fe of field-level default value of enums in internal definitions

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -207,13 +207,14 @@ const convertSchemaToUserDefinedTypes = definitionsSchema => {
 		return {
 			name: prepareName(key),
 			schema: convertSchema(definition),
+			originalSchema: definition,
 			customProperties,
 		}
 	});
 
-	return definitions.reduce((result, { name, schema, customProperties }) => ({
+	return definitions.reduce((result, { name, schema, customProperties, originalSchema }) => ({
 		...result,
-		[name]: { schema, customProperties },
+		[name]: { schema, customProperties, originalSchema },
 	}), {});
 };
 

--- a/forward_engineering/helpers/udtHelper.js
+++ b/forward_engineering/helpers/udtHelper.js
@@ -231,6 +231,7 @@ const convertCollectionReferences = (entities, options) => {
 			[reference.name]: {
 				isCollectionReference: true,
 				schema: {},
+				originalSchema: {},
 			}
 		}), {}));
 


### PR DESCRIPTION
# Context

https://app.gitbook.com/o/HBtg1gLTy0nw4NaX0MaV/s/k3cNzEeXGnIxGNnOQdDa/targets/plugins/avro/enum-data-type

When enum was in internal definitions with `Default` property, and the reference was not required, there was field-level default added in FE script