### PR TITLE
HCK-8136: enable resolving entity refs by default

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -63,7 +63,7 @@
 	"additionalOptions": [
 		{
 			"id": "resolveEntityReferences",
-			"value": false,
+			"value": true,
 			"name": "Resolve entity refs",
 			"level": {
 				"model": false


### PR DESCRIPTION
## Content

To ensure consistency between the CLI and GUI, the "resolve entity references" option will now be enabled by default in the GUI. This change aligns the GUI behavior with the default value of the `--defsStrategy` parameter in the CLI, which is set to "`resolved`".

...