### PR TITLE
HCK-9201: fix FE of Doc when it is provided in the choice

### DIFF
--- a/forward_engineering/helpers/convertJsonSchemaToAvro.js
+++ b/forward_engineering/helpers/convertJsonSchemaToAvro.js
@@ -322,13 +322,25 @@ const handleField = (name, field) => {
 			name: prepareName(name),
 			type: _.isArray(typeSchema.type) ? typeSchema.type : typeSchema,
 			default: getEnumDefaultValue(field, udt, typeSchema),
-			doc: field.$ref ? refDescription : description,
+			doc: getDoc({ field, refDescription, description }),
 			order,
 			aliases,
 			...customProperties,
 		},
 		typeSchema,
 	);
+};
+
+const getDoc = ({ field, refDescription, description }) => {
+	if (!field.$ref) {
+		return description;
+	}
+
+	if (field.choice) {
+		return description;
+	}
+
+	return refDescription;
 };
 
 const getEnumDefaultValue = (field, udt, typeSchema) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9201" title="HCK-9201" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9201</a>  Fix missing "doc" in the Avro script 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Fixed forward-engineering of choice's `doc` property when one of the subschemas have a reference.