### PR TITLE
HCK-9209

### DIFF
--- a/forward_engineering/helpers/convertJsonSchemaToAvro.js
+++ b/forward_engineering/helpers/convertJsonSchemaToAvro.js
@@ -322,13 +322,25 @@ const handleField = (name, field) => {
 			name: prepareName(name),
 			type: _.isArray(typeSchema.type) ? typeSchema.type : typeSchema,
 			default: getEnumDefaultValue(field, udt, typeSchema),
-			doc: field.$ref ? refDescription : description,
+			doc: getDoc({ field, refDescription, description }),
 			order,
 			aliases,
 			...customProperties,
 		},
 		typeSchema,
 	);
+};
+
+const getDoc = ({ field, refDescription, description }) => {
+	if (!field.$ref) {
+		return description;
+	}
+
+	if (field.choice) {
+		return description;
+	}
+
+	return refDescription;
 };
 
 const getEnumDefaultValue = (field, udt, typeSchema) => {

--- a/reverse_engineering/helpers/convertToJsonSchemas.js
+++ b/reverse_engineering/helpers/convertToJsonSchemas.js
@@ -336,7 +336,7 @@ const getOneOf = field => ({
 	items: field.type.map(typeData => ({
 		type: 'record',
 		subschema: true,
-		properties: { [field.name || DEFAULT_FIELD_NAME]: _.omit(typeData, 'name') },
+		properties: { [typeData.name || field.name || DEFAULT_FIELD_NAME]: _.omit(typeData, 'name') },
 	})),
 });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9209" title="HCK-9209" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9209</a>  Adapt RE logic to give appropriate name to sub-schema
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Fro union schema with records inside we generated `oneOf` choice with subschemas. In each subschema there was a reference to internal definition. The reference had a name the same as choice, and the definition had the name that is provided in type of union. e.g.
```json
{
            "name": "union_record", // name of choice and name of reference
            "type": [
                {
                    "name": "some_type", // name of definition
                    "type": "record",
                    "fields": [
                        {
                            "name": "key",
                            "type": "string"
                        }
                    ]
                },
                ...
            ]
        }
```

Now, we take the name of union type (definition in hackolade) and keep it for a reference as well

```json
{
            "name": "union_record", // name of choice
            "type": [
                {
                    "name": "some_type", // name of definition and name of reference
                    "type": "record",
                    "fields": [
                        {
                            "name": "key",
                            "type": "string"
                        }
                    ]
                },
                ...
            ]
        }
```