### PR TITLE
HCK-9201: fixed the proper priority of Doc property in union types

### DIFF
--- a/forward_engineering/helpers/convertChoicesToProperties.js
+++ b/forward_engineering/helpers/convertChoicesToProperties.js
@@ -55,6 +55,7 @@ const convertChoiceToProperties = (schema, choice) => {
 
 	const multipleFieldsHash = allSubSchemaFields.reduce((multipleFieldsHash, field, index) => {
 		const fieldName = choiceMeta.code || choiceMeta.name || field.name || getDefaultName();
+		const fieldDescription = choiceMeta.description || field.description || field.refDescription;
 		const multipleField = multipleFieldsHash[fieldName] || {
 			...choiceMeta,
 			default: convertDefaultMetaFieldType(field.type, choiceMeta.default),
@@ -64,6 +65,7 @@ const convertChoiceToProperties = (schema, choice) => {
 		};
 		const multipleTypeAttributes = {
 			...field,
+			...(fieldDescription && { description: fieldDescription }),
 			type: field.$ref ? getTypeFromReference(field) : field.type,
 			name: prepareName(field.name || fieldName),
 		};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9201" title="HCK-9201" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9201</a>  Fix missing "doc" in the Avro script 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

The description of union field should be taken from the choice if it ispresent, if not from a field in subschema