### PR TITLE
HCK-9333: fix reverse-engineering of confluentVersion as string

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -143,7 +143,9 @@ const getSchemasData = avroSchema => {
 		confluentSubjectName: schema.confluentSubjectName,
 		schemaTopic: schema.schemaTopic,
 		schemaType: schema.schemaType,
-		confluentVersion: String(schema.version),
+		...((typeof schema.version === 'number' || typeof schema.version === 'string') && {
+			confluentVersion: String(schema.version),
+		}),
 	}));
 };
 

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -143,7 +143,7 @@ const getSchemasData = avroSchema => {
 		confluentSubjectName: schema.confluentSubjectName,
 		schemaTopic: schema.schemaTopic,
 		schemaType: schema.schemaType,
-		confluentVersion: schema.version,
+		confluentVersion: String(schema.version),
 	}));
 };
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9333" title="HCK-9333" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9333</a>  It is impossible to open Avro model after RE from Confluent
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

The `confluentVersion` should be a string according to config.