### PR TITLE
HCK-9386: handle edge-case in FE when internal definition references model definition and they both have the same name

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -211,7 +211,7 @@ const convertJsonToAvro = (jsonSchema, schemaName) => {
 };
 
 /**
- * When we have a reference in the internal definitions that leads ot a definition
+ * When we have a reference in the internal definitions that leads to a definition
  * in the model definitions we need to resolve them to avoid creation of a UDT that references
  * itself. It may happen when the definition have the same name as the reference.
  *

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -12,6 +12,7 @@ const {
 	convertCollectionReferences,
 	resolveNamespaceReferences,
 	clearDefinitions,
+	resolveSchemaUdt,
 } = require('./helpers/udtHelper');
 const convertSchema = require('./helpers/convertJsonSchemaToAvro');
 const {
@@ -49,7 +50,7 @@ const generateModelScript = (data, logger, cb, app) => {
 				clearDefinitions();
 				addDefinitions(convertedExternalDefinitions);
 				addDefinitions(convertedModelDefinitions);
-				setUserDefinedTypes(internalDefinitions);
+				setUserDefinedTypes(internalDefinitions, true);
 				resetDefinitionsUsage();
 
 				const settings = getSettings({ containerData, entityData, modelData, references });
@@ -101,7 +102,7 @@ const generateScript = (data, logger, cb, app) => {
 
 		setUserDefinedTypes(externalDefinitions);
 		setUserDefinedTypes(modelDefinitions);
-		setUserDefinedTypes(internalDefinitions);
+		setUserDefinedTypes(internalDefinitions, true);
 		resetDefinitionsUsage();
 		const isFromUi = options.origin === 'ui';
 
@@ -209,11 +210,19 @@ const convertJsonToAvro = (jsonSchema, schemaName) => {
 	return resolveUdt(reorderAvroSchema(avroSchema));
 };
 
-const setUserDefinedTypes = definitions => {
-	addDefinitions(convertSchemaToUserDefinedTypes(definitions));
+/**
+ * When we have a reference in the internal definitions that leads ot a definition
+ * in the model definitions we need to resolve them to avoid creation of a UDT that references
+ * itself. It may happen when the definition have the same name as the reference.
+ *
+ * @param {Array<object>} definitions
+ * @param {boolean} [resolveReferences]
+ */
+const setUserDefinedTypes = (definitions, resolveReferences = false) => {
+	addDefinitions(convertSchemaToUserDefinedTypes(definitions, resolveReferences));
 };
 
-const convertSchemaToUserDefinedTypes = definitionsSchema => {
+const convertSchemaToUserDefinedTypes = (definitionsSchema, resolveReferences) => {
 	definitionsSchema = parseJson(definitionsSchema);
 	const definitions = Object.keys(definitionsSchema.properties || {}).map(key => {
 		const definition = definitionsSchema.properties[key];
@@ -230,7 +239,7 @@ const convertSchemaToUserDefinedTypes = definitionsSchema => {
 	return definitions.reduce(
 		(result, { name, schema, customProperties, originalSchema }) => ({
 			...result,
-			[name]: { schema, customProperties, originalSchema },
+			[name]: { schema: resolveReferences ? resolveSchemaUdt(schema) : schema, customProperties, originalSchema },
 		}),
 		{},
 	);

--- a/forward_engineering/helpers/udtHelper.js
+++ b/forward_engineering/helpers/udtHelper.js
@@ -1,4 +1,4 @@
-const { dependencies } = require('../../shared/appDependencies');
+const _ = require('lodash');
 const { isNamedType, filterAttributes } = require('../../shared/typeHelper');
 const { AVRO_TYPES, SCRIPT_TYPES } = require('../../shared/constants');
 const mapJsonSchema = require('../../shared/mapJsonSchema');
@@ -7,11 +7,9 @@ const mapAvroSchema = require('./mapAvroSchema');
 const { getConfluentSubjectName } = require('./formatAvroSchemaByType');
 const { prepareName } = require('./generalHelper');
 
-let _;
 let udt = {};
 
 const getUdtItem = type => {
-	_ = dependencies.lodash;
 	if (!_.isString(type)) {
 		return;
 	}
@@ -22,8 +20,6 @@ const getUdtItem = type => {
 };
 
 const resolveUdt = avroSchema => {
-	_ = dependencies.lodash;
-
 	return mapAvroSchema(avroSchema, resolveSchemaUdt);
 };
 
@@ -58,8 +54,6 @@ const isDefinitionTypeValidForAvroDefinition = definition => {
 };
 
 const resolveSchemaUdt = schema => {
-	_ = dependencies.lodash;
-
 	const type = _.isString(schema) || _.isArray(schema) ? schema : schema.type;
 	if (isNativeType(type)) {
 		return schema;
@@ -156,8 +150,6 @@ const convertNamedTypesToReferences = schema => {
 };
 
 const convertSchemaToReference = schema => {
-	_ = dependencies.lodash;
-
 	const referenceAttributes = filterAttributes(_.omit(schema, 'type'));
 
 	return reorderAttributes({ ...referenceAttributes, type: schema.name });
@@ -172,8 +164,6 @@ const clearDefinitions = () => {
 };
 
 const resetDefinitionsUsage = () => {
-	_ = dependencies.lodash;
-
 	udt = Object.keys(udt || {}).reduce((updatedUdt, key) => {
 		const definition = udt[key];
 
@@ -182,8 +172,6 @@ const resetDefinitionsUsage = () => {
 };
 
 const convertCollectionReferences = (entities, options) => {
-	_ = dependencies.lodash;
-
 	const entitiesIds = entities.map(entity => entity.jsonSchema.GUID);
 	const entitiesWithReferences = entities.map(entity => {
 		let references = [];
@@ -288,8 +276,6 @@ const filterReferencesByPath = (entity, references) =>
 	});
 
 const resolveNamespaceReferences = entities => {
-	_ = dependencies.lodash;
-
 	const entitiesWithReferences = entities.map(entity => {
 		const mapper = mapJsonSchema(field => {
 			if (!field.ref) {

--- a/forward_engineering/helpers/udtHelper.js
+++ b/forward_engineering/helpers/udtHelper.js
@@ -58,6 +58,8 @@ const isDefinitionTypeValidForAvroDefinition = definition => {
 };
 
 const resolveSchemaUdt = schema => {
+	_ = dependencies.lodash;
+
 	const type = _.isString(schema) || _.isArray(schema) ? schema : schema.type;
 	if (isNativeType(type)) {
 		return schema;
@@ -362,6 +364,7 @@ const getConfluentSchemaVersion = version => {
 
 module.exports = {
 	resolveUdt,
+	resolveSchemaUdt,
 	getUdtItem,
 	addDefinitions,
 	clearDefinitions,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9386" title="HCK-9386" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9386</a>  Fix the bug in the Avro plugin FE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

There was a reference in the internal definitions that references model definition. They both had the same name. So, in the udt we had the udt from internal definitions (because internal defs have higher priority), and when we tried to resolve it we stuck in the infinite loop returning the same reference all along.