### PR TITLE
HCK-9554: fixed forward-engineering of custom properties in different cases

### DIFF
--- a/forward_engineering/helpers/convertChoicesToProperties.js
+++ b/forward_engineering/helpers/convertChoicesToProperties.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const { filterMultipleTypes, prepareName, getDefaultName, convertName } = require('./generalHelper');
 const getTypeFromReference = require('./getTypeFromReference');
 const { AVRO_TYPES } = require('../../shared/constants');
+const { getFieldCustomProperties } = require('../../shared/customProperties');
 
 const CHOICES = ['oneOf', 'anyOf', 'allOf'];
 
@@ -49,6 +50,9 @@ const convertChoiceToProperties = (schema, choice) => {
 		};
 	}
 
+	// custom properties of choice have higher priority than custom properties of fields in subschemas
+	const choiceCustomProperties = getFieldCustomProperties({ schema: { ...choiceMeta, type: 'choice' } });
+
 	const multipleFieldsHash = allSubSchemaFields.reduce((multipleFieldsHash, field, index) => {
 		const fieldName = choiceMeta.code || choiceMeta.name || field.name || getDefaultName();
 		const fieldDescription = choiceMeta.description || field.description || field.refDescription;
@@ -77,6 +81,7 @@ const convertChoiceToProperties = (schema, choice) => {
 			[fieldName]: {
 				...convertName(multipleField),
 				...convertName(multipleTypeAttributes),
+				...choiceCustomProperties,
 				default: defaultValue,
 				type,
 			},

--- a/forward_engineering/helpers/convertJsonSchemaToAvro.js
+++ b/forward_engineering/helpers/convertJsonSchemaToAvro.js
@@ -12,7 +12,7 @@ const {
 } = require('./generalHelper');
 const convertChoicesToProperties = require('./convertChoicesToProperties');
 const { GENERAL_ATTRIBUTES, META_VALUES_KEY_MAP } = require('../../shared/constants');
-const { getFieldLevelConfig, getCustomProperties } = require('../../shared/customProperties');
+const { getFieldLevelConfig, getCustomProperties, getFieldCustomProperties } = require('../../shared/customProperties');
 const getTypeFromReference = require('./getTypeFromReference');
 
 const DEFAULT_TYPE = 'string';
@@ -311,8 +311,7 @@ const handleField = (name, field) => {
 	const { description, refDescription, default: __defaultValue, order, aliases, ...schema } = field;
 	const typeSchema = convertSchema(schema);
 	const udt = getUdtItem(typeSchema);
-	const customProperties =
-		getCustomProperties(getFieldLevelConfig(udt?.schema?.type || schema.type), schema) || udt?.customProperties;
+	const customProperties = getFieldCustomProperties({ schema, udt });
 
 	return resolveFieldDefaultValue(
 		{

--- a/forward_engineering/helpers/mapAvroSchema.js
+++ b/forward_engineering/helpers/mapAvroSchema.js
@@ -1,3 +1,6 @@
+const _ = require('lodash');
+const { GENERAL_ATTRIBUTES } = require('../../shared/constants');
+
 const mapAvroSchema = (avroSchema, iteratee) => {
 	if (Array.isArray(avroSchema)) {
 		return avroSchema.map(item => mapAvroSchema(item, iteratee));
@@ -13,9 +16,15 @@ const mapAvroSchema = (avroSchema, iteratee) => {
 		const fields = avroSchema.fields.map(field => {
 			const typeSchema = mapAvroSchema(field.type, iteratee);
 			if (Array.isArray(typeSchema.type)) {
+				// properties of a reference (field) have higher priority except of some
+				// Avro-related properties like `default` or `type`. Although, it is not possible to define these
+				// properties on the reference, I made such merge to be sure that we don't overwrite
+				// some definition properties that are necessary because I'm not aware of whole scope and impact
+				// of the change.
 				return {
-					...field,
+					..._.pick(field, GENERAL_ATTRIBUTES),
 					...typeSchema,
+					..._.omit(field, GENERAL_ATTRIBUTES),
 					doc: field.doc ?? typeSchema.doc,
 				};
 			}

--- a/forward_engineering/helpers/udtHelper.js
+++ b/forward_engineering/helpers/udtHelper.js
@@ -96,8 +96,9 @@ const getTypeFromUdt = type => {
 		return getTypeWithNamespace(type);
 	}
 
-	const { schema } = getUdtItem(type) || {};
+	const { schema, customProperties } = getUdtItem(type) || {};
 	let udtItem = resolveSymbolDefaultValue(schema);
+	udtItem = typeof schema === 'object' ? { ...udtItem, ...customProperties } : schema;
 
 	if (isDefinitionTypeValidForAvroDefinition(udtItem)) {
 		useUdt(type);

--- a/shared/customProperties.js
+++ b/shared/customProperties.js
@@ -83,9 +83,38 @@ const getFieldLevelConfig = type => {
 
 const getEntityLevelConfig = () => pluginConfiguration.entityLevelConfig?.flatMap(tab => tab?.structure || []) || [];
 
+const getFieldCustomProperties = ({ schema, udt }) => {
+	const customProperties = getCustomProperties(getFieldLevelConfig(getFieldType({ schema, udt })), schema);
+
+	if (
+		typeof udt?.schema === 'string' ||
+		(Array.isArray(udt?.schema) && udt?.schema.every(type => typeof type === 'string'))
+	) {
+		return { ...(udt?.customProperties || {}), ...(customProperties || {}) };
+	}
+
+	return customProperties || {};
+};
+
+const getFieldType = ({ schema, udt }) => {
+	if (udt?.schema?.type) {
+		return udt.schema.type;
+	}
+
+	if (
+		typeof udt?.schema === 'string' ||
+		(Array.isArray(udt?.schema) && udt?.schema.every(type => typeof type === 'string'))
+	) {
+		return udt.schema;
+	}
+
+	return schema?.type;
+};
+
 module.exports = {
 	initPluginConfiguration,
 	getCustomProperties,
 	getFieldLevelConfig,
 	getEntityLevelConfig,
+	getFieldCustomProperties,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9554" title="HCK-9554" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9554</a>  Custom properties aren't FE'd when defined on a reference
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Custom properties weren't forward-engineered correctly in some cases. Made FE of custom properties work in the same ways as `Doc` property.