### PR TITLE
HCK-9826: fix order of properties in the field when it is a reference on definition with multiple type

### DIFF
--- a/forward_engineering/helpers/mapAvroSchema.js
+++ b/forward_engineering/helpers/mapAvroSchema.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { GENERAL_ATTRIBUTES } = require('../../shared/constants');
+const { reorderAttributes } = require('./generalHelper');
 
 const mapAvroSchema = (avroSchema, iteratee) => {
 	if (Array.isArray(avroSchema)) {
@@ -21,12 +22,12 @@ const mapAvroSchema = (avroSchema, iteratee) => {
 				// properties on the reference, I made such merge to be sure that we don't overwrite
 				// some definition properties that are necessary because I'm not aware of whole scope and impact
 				// of the change.
-				return {
+				return reorderAttributes({
 					..._.pick(field, GENERAL_ATTRIBUTES),
 					...typeSchema,
 					..._.omit(field, GENERAL_ATTRIBUTES),
 					doc: field.doc ?? typeSchema.doc,
-				};
+				});
 			}
 
 			return {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9826" title="HCK-9826" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9826</a>  Fix order of properties
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
