### PR TITLE
HCL-10221: reorder props

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1729,6 +1729,10 @@ making sure that you maintain a proper JSON format.
 			"comments"
 		],
 		"multiple": [
+			"name",
+			"code",
+			"isActivated",
+			"type",
 			{
 				"propertyName": "Required",
 				"propertyKeyword": "required",
@@ -1762,6 +1766,14 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "details",
 				"template": "textarea"
 			},
+			"dependencies",
+			"primaryKey",
+			"foreignEntity",
+			"foreignField",
+			"relationshipType",
+			"relationshipName",
+			"cardinality",
+			"comments",
 			"dynamic"
 		],
 		"reference": [


### PR DESCRIPTION
## Technical details

* declared exact structure to make `required`, `default` and `doc` props to be right after Type section