### PR TITLE
HCK-10241: multiple type is not disabled

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1732,7 +1732,6 @@ making sure that you maintain a proper JSON format.
 			"name",
 			"code",
 			"isActivated",
-			"type",
 			{
 				"propertyName": "Required",
 				"propertyKeyword": "required",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10241" title="HCK-10241" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10241</a>  REGRESSION: Multiple types: main Type dropdown should mention "multiple" and be disabled
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* allow main app to control the root type behavior:

![image](https://github.com/user-attachments/assets/799c6952-6dac-40f8-bb05-0470d4cec579)
