### PR TITLE
HCK-10247: "Doc" stable placement

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1733,6 +1733,24 @@ making sure that you maintain a proper JSON format.
 			"code",
 			"isActivated",
 			{
+				"propertyName": "Doc",
+				"propertyKeyword": "description",
+				"propertyValidate": false,
+				"propertyTooltip": "Popup for multi-line text entry",
+				"propertyType": "details",
+				"template": "textarea"
+			},
+			{
+				"propertyName": "Type",
+				"propertyKeyword": "type",
+				"dependency": [
+					{
+						"key": "multiType",
+						"exist": false
+					}
+				]
+			},
+			{
 				"propertyName": "Required",
 				"propertyKeyword": "required",
 				"propertyType": "checkbox",
@@ -1756,14 +1774,6 @@ making sure that you maintain a proper JSON format.
 						"exist": false
 					}
 				]
-			},
-			{
-				"propertyName": "Doc",
-				"propertyKeyword": "description",
-				"propertyValidate": false,
-				"propertyTooltip": "Popup for multi-line text entry",
-				"propertyType": "details",
-				"template": "textarea"
 			},
 			"dependencies",
 			"primaryKey",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10247" title="HCK-10247" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10247</a>  [Avro][Multi] 'Doc' property unexpected movement when field type is changed to multi
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* proper placement of the Doc property when the multiple types are selected