### PR TITLE
HCK-10243: Union schema reference not nullable, it should be marked as mandatory * in ERD + default prop should not appear

### DIFF
--- a/central_pane/style.json
+++ b/central_pane/style.json
@@ -1,30 +1,55 @@
-/**
- * This config changes a visual appearance of entities in the application.
 {
 	"field": {
-		"dtd": [{
-			// supported css styles
-			"value": {
-				"border-style": "dashed",
-				"background": "#fff",
-				"color": "#333",
-				"font-style": "normal",
-				"font-weight": "normal",
-				"border-color": "#777",
-				"border-width": "1px"
-			},
-			"dependency": <condition that shows when to apply styles>
-		}],
-		// this property adds new columns or changes an order of current columns in the ERD box
 		"erd": [
-			"keys", "type", "indexes", {
-				"value": <constant| { "key": <fieldKeyword of property> }>,
-				"dependency": <condition for showing column>,
-				"width": <number in pixels, default: 50>
+			"keys",
+			"type",
+			{
+				"value": "#",
+				"title": "Pattern field",
+				"dependency": {
+					"key": "isPatternField",
+					"value": true
+				},
+				"width": 20
+			},
+			{
+				"value": " *",
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "required",
+							"value": true
+						},
+						{
+							"type": "or",
+							"values": [
+								{
+									"key": "nullable",
+									"value": false
+								},
+								{
+									"type": "and",
+									"values": [
+										{
+											"value": "collectionReference",
+											"key": "refType"
+										},
+										{
+											"key": "nullable",
+											"exists": false
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				"override": {
+					"value": "*"
+				},
+				"width": 20
 			}
 		]
 	}
 }
- */
-
-{}

--- a/central_pane/style.json
+++ b/central_pane/style.json
@@ -13,7 +13,7 @@
 				"width": 20
 			},
 			{
-				"value": " *",
+				"value": "*",
 				"dependency": {
 					"type": "or",
 					"values": [

--- a/central_pane/style.json
+++ b/central_pane/style.json
@@ -1,3 +1,32 @@
+/**
+ * This config changes a visual appearance of entities in the application.
+{
+	"field": {
+		"dtd": [{
+			// supported css styles
+			"value": {
+				"border-style": "dashed",
+				"background": "#fff",
+				"color": "#333",
+				"font-style": "normal",
+				"font-weight": "normal",
+				"border-color": "#777",
+				"border-width": "1px"
+			},
+			"dependency": <condition that shows when to apply styles>
+		}],
+		// this property adds new columns or changes an order of current columns in the ERD box
+		"erd": [
+			"keys", "type", "indexes", {
+				"value": <constant| { "key": <fieldKeyword of property> }>,
+				"dependency": <condition for showing column>,
+				"width": <number in pixels, default: 50>
+			}
+		]
+	}
+}
+ */
+
 {
 	"field": {
 		"erd": [

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -913,6 +913,15 @@ making sure that you maintain a proper JSON format.
 							"type": "or",
 							"values": [
 								{
+									"key": "nullable",
+									"value": true
+								}
+							]
+						},
+						{
+							"type": "or",
+							"values": [
+								{
 									"key": "required",
 									"value": false
 								},


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10243" title="HCK-10243" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10243</a>  7) Union schema reference not nullable, it should be marked as mandatory * in ERD + default prop should not appear
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- Improve ERD visualisation 
- Improve PP validation