### PR TITLE
HCK-10295: fix FE of default value for numeric types

### DIFF
--- a/forward_engineering/helpers/convertJsonSchemaToAvro.js
+++ b/forward_engineering/helpers/convertJsonSchemaToAvro.js
@@ -317,7 +317,7 @@ const handleField = (name, field) => {
 		{
 			name: prepareName(name),
 			type: _.isArray(typeSchema.type) ? typeSchema.type : typeSchema,
-			default: getEnumDefaultValue(field, udt, typeSchema),
+			default: getDefaultValue(field, udt, typeSchema),
 			doc: getDoc({ field, refDescription, description }),
 			order,
 			aliases,
@@ -337,6 +337,12 @@ const getDoc = ({ field, refDescription, description }) => {
 	return refDescription;
 };
 
+const getDefaultValue = (field, udt, typeSchema) => {
+	const defaultValue = getEnumDefaultValue(field, udt, typeSchema);
+
+	return convertDefaultValueToTypeOfField(field, defaultValue);
+};
+
 const getEnumDefaultValue = (field, udt, typeSchema) => {
 	if (!_.isUndefined(field?.default) || typeSchema?.type === 'enum') {
 		return field?.default;
@@ -347,6 +353,18 @@ const getEnumDefaultValue = (field, udt, typeSchema) => {
 	}
 
 	return typeSchema?.default;
+};
+
+const convertDefaultValueToTypeOfField = (field, defaultValue) => {
+	if (!defaultValue) {
+		return defaultValue;
+	}
+
+	if (field.type === 'number') {
+		return _.toNumber(defaultValue);
+	}
+
+	return defaultValue;
 };
 
 const resolveFieldDefaultValue = (field, type) => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10291" title="HCK-10291" target="_blank"><img alt="Bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10291</a>  Avro: default value of numeric field derived from Polyglot is incorrectly surrounded by quotes in FE to Avro AVSC file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

Sometimes for numeric types default value is a string in the model (e.g. `"default": "3"`). It is fine and this PR handles this case.