### PR TITLE
HCK-10314: missing default property

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -350,11 +350,65 @@ making sure that you maintain a proper JSON format.
 				},
 				"typeDecorator": true
 			},
+			"required",
 			{
-				"propertyName": "Required",
-				"propertyKeyword": "required",
-				"propertyType": "checkbox",
-				"template": "boolean"
+				"propertyName": "Default",
+				"propertyKeyword": "default",
+				"shouldValidate": true,
+				"propertyType": "text",
+				"validation": {
+					"required": true
+				},
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"type": "or",
+							"values": [
+								{
+									"key": "required",
+									"value": false
+								},
+								{
+									"key": "required",
+									"exist": false
+								}
+							]
+						},
+						{
+							"type": "not",
+							"values": {
+								"level": "parent",
+								"key": "childType",
+								"value": "array"
+							}
+						},
+						{
+							"key": "subtype",
+							"value": "decimal"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "Default",
+				"propertyKeyword": "default",
+				"shouldValidate": true,
+				"propertyType": "text",
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"level": "parent",
+							"key": "childType",
+							"value": "array"
+						},
+						{
+							"key": "subtype",
+							"value": "decimal"
+						}
+					]
+				}
 			},
 			{
 				"propertyName": "Aliases",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10314" title="HCK-10314" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10314</a>  [Avro] Default value of decimal numeric field ignored during derive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* extended field level config to properly handle default value derived from a polyglot model