### PR TITLE
HCK-12025: fix handling required multiple with complex type

### DIFF
--- a/reverse_engineering/helpers/adaptJsonSchema.js
+++ b/reverse_engineering/helpers/adaptJsonSchema.js
@@ -57,12 +57,15 @@ const handleEmptyDefaultInProperties = field => {
 
 	const properties = propertiesKeys.reduce((properties, key) => {
 		const propertyValue = field.properties[key];
-		if (required.includes(key)) {
+		const isMultiple = Array.isArray(propertyValue.type);
+		const isMultipleWithComplexType = isMultiple && propertyValue.type.find(isComplexType);
+
+		if (required.includes(key) && !isMultipleWithComplexType) {
 			return { ...properties, [key]: propertyValue };
 		}
 
 		const property = handleEmptyDefault(propertyValue);
-		if (propertyValue === property || !_.isArray(property.type)) {
+		if (propertyValue === property || !Array.isArray(property.type)) {
 			return { ...properties, [key]: propertyValue };
 		}
 

--- a/shared/mapJsonSchema.js
+++ b/shared/mapJsonSchema.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const PROPERTIES_LIKE = ['properties', 'definitions', 'patternProperties'];
+const PROPERTIES_LIKE = ['properties', 'definitions', 'patternProperties', '$defs'];
 const ITEMS_LIKE = ['items', 'oneOf', 'allOf', 'anyOf', 'not'];
 
 const mapJsonSchema =


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12025" title="HCK-12025" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12025</a>  Fix processing of multiple type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Avro does not support multiple types when one or more of the types is a complex type. In such cases, these should be converted into a `oneOf` choice to ensure compatibility.

Previously, there was a missed case where complex multiple types were not processed correctly if the field was marked as required in the JSON Schema. This led to a mix of processed and unprocessed complex types, resulting in unpredictable behavior on the application side.

This PR fixes that edge case by ensuring that complex multiple types are consistently converted to `oneOf`, even for required fields.