### PR TITLE
HCK-12071: convert string with enum to enum type with symbols on RE from JSON Schema

### DIFF
--- a/reverse_engineering/helpers/adaptJsonSchema.js
+++ b/reverse_engineering/helpers/adaptJsonSchema.js
@@ -20,6 +20,10 @@ const adaptType = field => {
 		return adaptMultiple(field);
 	}
 
+	if (type === 'string') {
+		return handleString(field);
+	}
+
 	if (type === 'number') {
 		return handleNumber(field);
 	}
@@ -251,6 +255,18 @@ const convertToValidAvroName = name => {
 	}
 
 	return name.replace(/[^A-Za-z0-9_]/g, '_');
+};
+
+const handleString = field => {
+	if (Array.isArray(field.enum) && field.enum.length > 0) {
+		return {
+			...field,
+			type: 'enum',
+			symbols: field.enum,
+		};
+	}
+
+	return field;
 };
 
 module.exports = { adaptJsonSchema, adaptJsonSchemaName };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12071" title="HCK-12071" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-12071</a>  The field with enum is not reverse-engineered as enum type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Avro have separate type for enums --- `enum`. When we RE from JSON Schema, field with type `string` and property `enum` should be converted to `enum` type in avro