### PR TITLE
HCK-12388: use UDT name while referencing

### DIFF
--- a/forward_engineering/helpers/udtHelper.js
+++ b/forward_engineering/helpers/udtHelper.js
@@ -132,10 +132,10 @@ const getTypeWithNamespace = type => {
 	}
 
 	if (!udtItem.schema.namespace) {
-		return type;
+		return udtItem.schema.name || type;
 	}
 
-	return udtItem.schema.namespace + '.' + type;
+	return udtItem.schema.namespace + '.' + udtItem.schema.name || type;
 };
 
 const convertNamedTypesToReferences = schema => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12388" title="HCK-12388" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12388</a>  Fix referenced UDT name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

The prepared UDT name should be used for the reference `type`.

The UDT name can be the following value from the definition object: "Type name", "Technical name", or "Name".

...