### PR TITLE
HCK-14077: fix FE of union fields generated from choices

### DIFF
--- a/forward_engineering/helpers/convertChoicesToProperties.js
+++ b/forward_engineering/helpers/convertChoicesToProperties.js
@@ -53,35 +53,55 @@ const convertChoiceToProperties = (schema, choice) => {
 	// custom properties of choice have higher priority than custom properties of fields in subschemas
 	const choiceCustomProperties = getFieldCustomProperties({ schema: { ...choiceMeta, type: 'choice' } });
 
+	const choiceName =
+		choiceMeta.code ||
+		choiceMeta.name ||
+		allSubSchemaFields[0]?.code ||
+		allSubSchemaFields[0]?.name ||
+		getDefaultName();
+
+	const fieldWithDescription = allSubSchemaFields.findLast(field => field.description || field.refDescription);
+	const choiceDescription =
+		choiceMeta.description || fieldWithDescription?.description || fieldWithDescription?.refDescription;
+
 	const multipleFieldsHash = allSubSchemaFields.reduce((multipleFieldsHash, field, index) => {
-		const fieldName = choiceMeta.code || choiceMeta.name || field.name || getDefaultName();
-		const fieldDescription = choiceMeta.description || field.description || field.refDescription;
-		const multipleField = multipleFieldsHash[fieldName] || {
+		const multipleField = multipleFieldsHash[choiceName] || {
 			...choiceMeta,
 			default: convertDefaultMetaFieldType(field.type, choiceMeta.default),
-			name: prepareName(fieldName),
+			name: prepareName(choiceName),
 			type: [],
 			choiceMeta,
 		};
 		const multipleTypeAttributes = {
 			...field,
-			...(fieldDescription && { description: fieldDescription }),
+			// When the choice have the description property, we show it and ignore the property in the fields
+			// when the field is not a reference. If it is a reference, the field can have the description of the
+			// but it will come from the definition and its not handled here.
+			//
+			// When the choice have no description we take the description of a field and put it into choice, at the same
+			// time removing it from field.
+			description: undefined,
 			type: field.$ref ? getTypeFromReference(field) : field.type,
-			name: prepareName(field.name || fieldName),
+			name: prepareName(field.code || field.name || choiceName),
 		};
-		const multipleTypes = filterMultipleTypes(ensureArray(multipleField.type).concat(multipleTypeAttributes));
+		const multipleTypes = ensureArray(multipleField.type).concat(multipleTypeAttributes);
 		const type = _.isArray(multipleTypes)
-			? multipleTypes.map(typeSchema => typeSchema?.type || typeSchema)
+			? multipleTypes.map(typeSchema =>
+					['fixed', 'enum', 'record'].includes(typeSchema?.type)
+						? typeSchema
+						: typeSchema?.type || typeSchema,
+				)
 			: multipleTypes?.type || multipleTypes;
 		const defaultFromSubschema = index === 0 ? multipleTypeAttributes.default : undefined;
 		const defaultValue = !_.isUndefined(multipleField.default) ? multipleField.default : defaultFromSubschema;
 
 		return {
 			...multipleFieldsHash,
-			[fieldName]: {
+			[choiceName]: {
 				...convertName(multipleField),
 				...convertName(multipleTypeAttributes),
 				...choiceCustomProperties,
+				...(choiceDescription && { description: choiceDescription }),
 				default: defaultValue,
 				type,
 			},

--- a/forward_engineering/helpers/generalHelper.js
+++ b/forward_engineering/helpers/generalHelper.js
@@ -40,7 +40,7 @@ const setPropertyAsFirst = key => avroSchema => {
 };
 
 const filterMultipleTypes = schemaTypes => {
-	const types = _.uniqBy(schemaTypes, type => type?.type || type);
+	const types = _.uniqBy(schemaTypes, type => type);
 	if (types.length === 1) {
 		return _.first(types);
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14077" title="HCK-14077" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-14077</a>  Improve FE of oneOf fields
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

The name of the final field with union type in the generated Avro schema should be taken by the logic:
```mermaid
graph TD

    A[Field name?] --> B{"Does the oneOf choice have a (technical) name?"}

    B -->|Yes| C["Field name = oneOf (technical) name"]

    B -->|No| D["Field name = (technical) name of the first  subschema"]

    C --> G[End]
    D --> G
```

The name of `record`/`fixed`/enum` should be taken by the logic:

```mermaid
graph TD

  A[Name of named type record-enum-fixed?] --> B{"Is the 'Type name' property of the attribute record/enum/fixed filled?"}

    B -->|Yes| C["Name of type record/enum/fixed = 'Type name' property of the attribute record/enum/fixed"]

    B -->|No|R{"Is it a reference?"} 

    -->|No|D["Name of type record/enum/fixed = (technical) name of the attribute record/enum/fixed"]
    R -->|Yes|E["Name of type record/enum/fixed = (technical) name of the referenced definition"]
    
    C --> G[End]
    D --> G
    E --> G
```