### PR TITLE
HCK-14142: fix the priority of definitions and records in FE on model level

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -11,6 +11,7 @@ const {
 	resolveNamespaceReferences,
 	clearDefinitions,
 	resolveSchemaUdt,
+	getDefinitionsOfCollectionReferences,
 } = require('./helpers/udtHelper');
 const convertSchema = require('./helpers/convertJsonSchemaToAvro');
 const {
@@ -42,7 +43,10 @@ const generateModelScript = (data, logger, cb, app) => {
 				externalDefinitions: parseJson(externalDefinitions),
 			}));
 
-		const script = handleCollectionReferences(entities, options).map(entity => {
+		const entitiesWithHandledCollectionReferences = handleCollectionReferences(entities, options);
+		const collectionDefinitions = getDefinitionsOfCollectionReferences();
+
+		const script = entitiesWithHandledCollectionReferences.map(entity => {
 			try {
 				const { containerData, entityData, jsonSchema, internalDefinitions, references } = entity;
 
@@ -50,6 +54,7 @@ const generateModelScript = (data, logger, cb, app) => {
 				addDefinitions(convertedExternalDefinitions);
 				addDefinitions(convertedModelDefinitions);
 				setUserDefinedTypes(internalDefinitions, true);
+				addDefinitions(collectionDefinitions);
 				resetDefinitionsUsage();
 
 				const settings = getSettings({ containerData, entityData, modelData, references });

--- a/forward_engineering/helpers/udtHelper.js
+++ b/forward_engineering/helpers/udtHelper.js
@@ -369,6 +369,10 @@ const getExternalReferenceDefinition = (field, externalDefinitions) => {
 	});
 };
 
+const getDefinitionsOfCollectionReferences = () => {
+	return Object.fromEntries(Object.entries(udt).filter(([key, value]) => value?.isCollectionReference));
+};
+
 module.exports = {
 	resolveUdt,
 	resolveSchemaUdt,
@@ -379,4 +383,5 @@ module.exports = {
 	resetDefinitionsUsage,
 	convertCollectionReferences,
 	resolveNamespaceReferences,
+	getDefinitionsOfCollectionReferences,
 };


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14142" title="HCK-14142" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14142</a>  [PROD] Avro FE: Union branch for referenced record is generated inline instead of type reference (duplicate type name)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

When we do FE on entity level we first insert the definitions (external/model/internal) and then insert the referenced records into the `udt` list. But on model level we were doing the opposite, first the records were inserted, but then, they were removed and external/model/internal definitions were added. It was causing incorrect resolution of references on records. This PR preserves the referenced records and ensures that they have the same priority as on entity level.