### PR TITLE
HCK-15742: add json schema property name alias

### DIFF
--- a/jsonSchemaProperties.json
+++ b/jsonSchemaProperties.json
@@ -1,4 +1,7 @@
 {
 	"unneededFieldProps": ["collectionName", "name", "users", "indexes", "collectionUsers"],
-	"removeIfPropsNegative": ["partitionKey", "sortKey"]
+	"removeIfPropsNegative": ["partitionKey", "sortKey"],
+	"propertyNameAlias": {
+		"symbols": "enum"
+	}
 }


### PR DESCRIPTION
## Technical details

Some attribute property names differ in target and in JSON schema (`symbols` in Avro is equal to `enum` property in JSON schema)